### PR TITLE
Move queries to Model class, add tests and use agg builder

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,90 +1,30 @@
 <?php
 namespace App\Http\Controllers;
 use App\Models\Movie;
+use Illuminate\Http\JsonResponse;
+
 class SearchController extends Controller
 {
-   public function search($search)
+   public function search($search): JsonResponse
    {
        // Define the aggregation based on the search conditions
        if (!empty($search)) {
-           $searcher_aggregate = [
-               [
-                   '$search' => [
-                       'index' => 'movie_search',
-                       'compound' => [
-                           'must' => [
-                               [
-                                   'text' => [
-                                       'query' => $search,
-                                       'path' => 'title',
-                                       'fuzzy' => new \stdClass() // Adding fuzzy matching
-                                   ]
-                               ]
-                           ]
-                       ]
-                   ]
-               ],
-               [
-                   '$limit' => 20
-               ],
-               [
-                   '$project' =>[
-                     'title' => 1,
-                     'genres' => 1,
-                     'poster'=> 1,
-                     'rated'=> 1,
-                     'plot' => 1,
-                   ]
-               ],
-           ];
+           $items = Movie::searchByTitle($search);
 
-           // Execute the aggregation query on the collection
-           $items = Movie::raw(function ($collection) use ($searcher_aggregate) {
-               return $collection->aggregate($searcher_aggregate);
-           });
            return response()->json($items, 200);
        }
+
        return response()->json(['error' => 'conditions not met'], 400);
    }
 
-
-   public function autocomplete($param)
+   public function autocomplete($param): JsonResponse
    {
        try {
-           // Define the aggregation pipeline
-           $searcher_aggregate = [
-               [
-                   '$search' => [
-                       'index' => 'movie_title_autocomplete',
-                       'autocomplete' => [
-                           'query' => $param,
-                           'path' => 'title',
-                       ],
-                       'highlight' => [
-                           'path' => ['title']
-                       ]
-                   ]
-               ],
-               ['$limit' => 5], // Limit the result to 5
-               [
-                   '$project' => [
-                       'title' => 1,
-                       'highlights' => ['$meta' => 'searchHighlights']
-                   ]
-               ]
-           ];
-
-
-           // Execute the aggregation query
-           $results = Movie::raw(function ($collection) use ($searcher_aggregate) {
-               return $collection->aggregate($searcher_aggregate);
-           });
-
+          $results = Movie::autocompleteByTitle($param);
 
            return response()->json($results, 200);
        } catch (\Exception $e) {
            return response()->json(['error' => $e->getMessage()], 500);
        }
    }
-
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -2,10 +2,80 @@
 
 namespace App\Models;
 
+use Illuminate\Support\Collection;
 use MongoDB\Laravel\Eloquent\Model;
 
 class Movie extends Model
 {
     protected $connection = 'mongodb';
-    
+
+    public static function searchByTitle(string $input): Collection
+    {
+        $searcher_aggregate = [
+            [
+                '$search' => [
+                    'index' => 'movie_search',
+                    'compound' => [
+                        'must' => [
+                            [
+                                'text' => [
+                                    'query' => $input,
+                                    'path' => 'title',
+                                    'fuzzy' => new \stdClass() // Adding fuzzy matching
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                '$limit' => 20
+            ],
+            [
+                '$project' =>[
+                    'title' => 1,
+                    'genres' => 1,
+                    'poster'=> 1,
+                    'rated'=> 1,
+                    'plot' => 1,
+                ]
+            ],
+        ];
+
+        // Execute the aggregation query on the collection
+        return self::raw(function ($collection) use ($searcher_aggregate) {
+            return $collection->aggregate($searcher_aggregate);
+        });
+    }
+
+    public static function autocompleteByTitle(string $input): Collection
+    {
+        // Define the aggregation pipeline
+        $searcher_aggregate = [
+            [
+                '$search' => [
+                    'index' => 'movie_title_autocomplete',
+                    'autocomplete' => [
+                        'query' => $input,
+                        'path' => 'title',
+                    ],
+                    'highlight' => [
+                        'path' => ['title']
+                    ]
+                ]
+            ],
+            ['$limit' => 5], // Limit the result to 5
+            [
+                '$project' => [
+                    'title' => 1,
+                    'highlights' => ['$meta' => 'searchHighlights']
+                ]
+            ]
+        ];
+
+        // Execute the aggregation query
+        return self::raw(function ($collection) use ($searcher_aggregate) {
+            return $collection->aggregate($searcher_aggregate);
+        });
+    }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -5,77 +5,48 @@ namespace App\Models;
 use Illuminate\Support\Collection;
 use MongoDB\Laravel\Eloquent\Model;
 
+
 class Movie extends Model
 {
     protected $connection = 'mongodb';
 
     public static function searchByTitle(string $input): Collection
     {
-        $searcher_aggregate = [
-            [
-                '$search' => [
-                    'index' => 'movie_search',
-                    'compound' => [
-                        'must' => [
-                            [
-                                'text' => [
-                                    'query' => $input,
-                                    'path' => 'title',
-                                    'fuzzy' => new \stdClass() // Adding fuzzy matching
-                                ]
+        return self::aggregate()
+            ->search([
+                'index' => 'movie_search',
+                'compound' => [
+                    'must' => [
+                        [
+                            'text' => [
+                                'query' => $input,
+                                'path' => 'title',
+                                'fuzzy' => new \stdClass() // Adding fuzzy matching
                             ]
                         ]
                     ]
                 ]
-            ],
-            [
-                '$limit' => 20
-            ],
-            [
-                '$project' =>[
-                    'title' => 1,
-                    'genres' => 1,
-                    'poster'=> 1,
-                    'rated'=> 1,
-                    'plot' => 1,
-                ]
-            ],
-        ];
-
-        // Execute the aggregation query on the collection
-        return self::raw(function ($collection) use ($searcher_aggregate) {
-            return $collection->aggregate($searcher_aggregate);
-        });
+            ])
+            ->limit(20)
+            ->project(title: 1, genres: 1, poster: 1, rated: 1, plot: 1)
+        ->get();
     }
 
     public static function autocompleteByTitle(string $input): Collection
     {
-        // Define the aggregation pipeline
-        $searcher_aggregate = [
-            [
-                '$search' => [
-                    'index' => 'movie_title_autocomplete',
-                    'autocomplete' => [
-                        'query' => $input,
-                        'path' => 'title',
-                    ],
-                    'highlight' => [
-                        'path' => ['title']
-                    ]
+        return self::aggregate()
+            ->search([
+                'index' => 'movie_title_autocomplete',
+                'autocomplete' => [
+                    'query' => $input,
+                    'path' => 'title'
+                ],
+                'highlight' => [
+                    'path' => ['title']
                 ]
-            ],
-            ['$limit' => 5], // Limit the result to 5
-            [
-                '$project' => [
-                    'title' => 1,
-                    'highlights' => ['$meta' => 'searchHighlights']
-                ]
-            ]
-        ];
-
-        // Execute the aggregation query
-        return self::raw(function ($collection) use ($searcher_aggregate) {
-            return $collection->aggregate($searcher_aggregate);
-        });
+            ])
+            ->limit(5) // Limit the result to 5
+            ->project(title: 1, highlights: ['$meta' => 'searchHighlights'])
+            ->get();
     }
 }

--- a/tests/Integration/SearchMovieTest.php
+++ b/tests/Integration/SearchMovieTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Movie;
+use Tests\TestCase;
+
+class SearchMovieTest extends TestCase
+{
+    public function test_search_movie_by_title_with_exact_match(): void
+    {
+        $results = Movie::searchByTitle('the matrix');
+        $titles = $results->pluck('title')->toArray();
+
+        self::assertCount(20, $titles);
+        self::assertSame('The Matrix', $titles[0]);
+        self::assertContains('The Matrix Reloaded', $titles);
+        self::assertContains('Armitage: Dual Matrix', $titles);
+    }
+
+    public function test_search_movie_without_result(): void
+    {
+        $results = Movie::searchByTitle('AZERTY');
+
+        self::assertCount(0, $results);
+    }
+
+    public function test_autocomplete_movie_by_title(): void
+    {
+        $results = Movie::autocompleteByTitle('matr');
+        $titles = $results->pluck('title')->toArray();
+
+        self::assertCount(5, $titles);
+        self::assertContains('The Matrix Reloaded', $titles);
+        self::assertContains('The Matrix Revolutions', $titles);
+        self::assertArrayHasKey('highlights', $results[0]);
+    }
+}


### PR DESCRIPTION
- Moving the search aggregations to the `Movie`  model class make it easier to reuse and test
- Adding tests on search results, because we all know that working with search index configuration requires a lot of try. Testing the direct results is way easier than the output JSON
- The Aggregation Builder makes code more concise and easier to read.